### PR TITLE
Instead of overriding the whole Form template, override blocks. Do not merge yet

### DIFF
--- a/templates/forms/form.html.twig
+++ b/templates/forms/form.html.twig
@@ -1,21 +1,9 @@
-<div class="alert">{{ form.message }}</div>
+{% extends "forms/default/form.html.twig" %}
 
-<form name="{{ form.name }}"
-      action="{{ uri.rootUrl ~ (form.action|default(page.route)) }}"
-      method="{{ form.method|upper|default('POST') }}" class="contact-form commentsblock">
-{% for field in form.fields %}
-    {% set value = form.value(field.name) %}
-    <div>
-        {% include "forms/fields/#{field.type}/#{field.type}.html.twig" %}
-    </div>
-{% endfor %}
+{% block form_classes %}
+class="contact-form commentsblock"
+{% endblock %}
 
-	<div class="buttons">
-	{% for button in form.buttons %}
-	    <button class="pushbutton-wide" type="{{ button.type|default('submit') }}">{{ button.value|default('Submit') }}</button>
-	{% endfor %}
-	</div>
-
-	{{ nonce_field('form', 'form-nonce') }}
-
-</form>
+{% block button_classes %}
+class="pushbutton-wide"
+{% endblock %}


### PR DESCRIPTION
Noticed it was overriding just to add some classes. This new method will be possible in the next Form Plugin release, as I just added this possibility.
Applies to Deliver and Gateway only.
