### PR TITLE
Update to use appropriate page.url for pagination

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -31,7 +31,7 @@
         {% endfor %}
 
         {% if config.plugins.pagination.enabled and collection.params.pagination %}
-        {% include 'partials/pagination.html.twig' with {'pagination':collection.params.pagination} %}
+        {% include 'partials/pagination.html.twig' with {'base_url': page.url, 'pagination':collection.params.pagination} %}
         {% endif %}
       </main>
     </div>


### PR DESCRIPTION
The existing parameter doesn't work appropriately with the pagination plugin