### PR TITLE
Set base_url for taxonomy lists

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -18,7 +18,7 @@
     <div class="large-{% if not page.header.fullwidth %}8{% else %}12{% endif %} columns">
       <main id="main" class="site-main" role="main">
         <div class="row">
-          {% include 'partials/blog_item.html.twig' with {'truncate':false,'big_header':true} %}
+          {% include 'partials/blog_item.html.twig' with {'truncate':false,'big_header':true,'base_url':the_base_url} %}
         </div>
       </main>
     </div>

--- a/templates/partials/sidebar.html.twig
+++ b/templates/partials/sidebar.html.twig
@@ -7,7 +7,7 @@
 {% if config.plugins.taxonomylist.enabled %}
 <aside class="widget widget_categories">
     <h1 class="widget-title">Categories</h1>
-    {% include 'partials/categorylist.html.twig' with {'taxonomy':'category'} %}
+    {% include 'partials/categorylist.html.twig' with {'taxonomy':'category', 'base_url':the_base_url} %}
 </aside>
 {% endif %}
 {% if config.plugins.random.enabled %}
@@ -33,7 +33,7 @@
 {% if config.plugins.taxonomylist.enabled %}
 <aside class="widget widget_tag_cloud">
     <h1 class="widget-title">Popular Tags</h1>
-    {% include 'partials/taxonomylist.html.twig' with {'taxonomy':'tag'} %}
+    {% include 'partials/taxonomylist.html.twig' with {'taxonomy':'tag', 'base_url':the_base_url} %}
 </aside>
 {% endif %}
 {% if config.plugins.feed.enabled %}


### PR DESCRIPTION
Links from taxonomy lists always went to root of site and didn't show any items.  Suggested change to propogate base url to taxonomy list. 