### PR TITLE
Improve truncated blog summaries

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -44,12 +44,14 @@
     {{ page.content|truncate(200, true)|raw }}
     {% elseif truncate and page.summary != page.content %}
     <p>
-      {{ page.summary|striptags }}
-      <a href="{{ page.url }}">more...</a>
+    {{ page.content|replace({'</p>':'<br />'})|striptags('<br>')|truncate(200, true) }}
     </p>
+    {% elseif truncate and page.summary != page.content %}
+    {{ page.summary|striptags('<br><p>') }}
+    <a href="{{ page.url }}">more...</a>
     {% elseif truncate %}
     <p>
-      {{ page.content|truncate(550)|striptags }}
+      {{ page.content|replace({'</p>':'<br />'})|striptags('<br>')|truncate(550) }}
       <a href="{{ page.url }}">more...</a>
     </p>
     {% else %}


### PR DESCRIPTION
Summaries for featured items previously could be truncated half way through a tag such as an `<a>` which lead to subsequent comment link being styles as a link in red.

Also updated other truncated summaries to replace paragraph closes with a line break so paragraphs in summaries aren't completely merged.  When using page summary, this isn't required.