### PR TITLE
Update blog_item.html.twig; fixed jscomments

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -192,7 +192,7 @@
   <div class="comments-area-wrapper">
     <div class="comments-area">
     <h2 class="comments-title">Comments:</h2>
-      {{ jscomments(config.plugins.jscomments.provider) }}
+      {{ jscomments() | raw }}
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
according to https://github.com/Sommerregen/grav-plugin-jscomments this is now need to be done, so that the js comments will be displayed.

With the current line, the script tag will be just printed