### PR TITLE
Fixed sidebar and blog item twigs

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,7 +1,8 @@
 <article {% if loop.index %}id="post-{{ loop.index }}"{% endif %} class="clearfix {% if loop.index %}post-{{ loop.index }}{% endif %} post type-post format-standard has-post-thumbnail {% if truncate %}{% if page.header.post_class %}{{ page.header.post_class }}{% endif %}{% endif %} hentry category-featured">
-  <div class="featured-image">
+{#  <div class="featured-image">
     {{ page.media.images|first.cropZoom(356,356).html|raw }}
   </div>
+#}
   <header class="entry-header">
     <h3 class="entry-title">
       {% if page.header.link %}
@@ -12,7 +13,7 @@
     </h3>
     {% if truncate %}
     <div class="entry-date">
-      {{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('n') - 1) }} {{ page.date|date('d, Y') }}
+      {{ page.date|date('F d, Y') }}
     </div>
     {% endif %}
 
@@ -20,8 +21,8 @@
     <div class="entry-meta">
       <span class="posted-on">Posted on
         <a href="{{ page.url }}" rel="bookmark">
-          <time class="entry-date published" datetime="{{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('n') - 1) }} {{ page.date|date('d, Y') }}">
-            {{ 'MONTHS_OF_THE_YEAR'|ta(page.date|date('n') - 1) }} {{ page.date|date('d, Y') }}
+          <time class="entry-date published" datetime="{{ page.date|date('c') }}">
+            {{ page.date|date('F d, Y') }}
           </time>
         </a>
       </span>

--- a/templates/partials/sidebar.html.twig
+++ b/templates/partials/sidebar.html.twig
@@ -17,7 +17,7 @@
 </aside>
 {% endif %}
 <aside class="widget widget_categories">
-	<h1 class="widget-title">Some Text Widget</h1>
+	<h1 class="widget-title">Edit in Sidebar.html.twig file</h1>
 	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna.</p>
 </aside>
 <aside class="widget widget_recent_entries">


### PR DESCRIPTION
Fixed some code in blog_item twig file that would cause the date of upload to show up as "MONTHS_OF_YEAR." Changed some code in the sidebar so that when it appears in the theme, the user knows exactly where to go to make that change.